### PR TITLE
fix: Update CPU runs-on labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   build:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on:
+      group: self-hosted
+      labels: cpu
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -35,7 +37,9 @@ jobs:
         run: go test -v ./...
   docker:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on:
+      group: self-hosted
+      labels: cpu
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   tag:
     name: Tag latest action version
-    runs-on: ubuntu-latest
+    runs-on:
+      group: self-hosted
+      labels: cpu
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Update workflow to use `cpu` instead of `cpu-dind` for runs-on labels